### PR TITLE
Rename IdleDetector app theme composable

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
                     )
                 },
                 content = {
-                    IdledetectorappTheme {
+                    IdleDetectorAppTheme {
                         AppContent()
                     }
                 })

--- a/app/src/main/java/ke/co/banit/idle_detector_app/MainActivity.kt
+++ b/app/src/main/java/ke/co/banit/idle_detector_app/MainActivity.kt
@@ -5,7 +5,7 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import ke.co.banit.idle_detector_app.ui.theme.IdledetectorappTheme
+import ke.co.banit.idle_detector_app.ui.theme.IdleDetectorAppTheme
 import ke.co.banit.idle_detector_compose.IdleDetectorProvider
 import kotlin.time.Duration.Companion.seconds
 
@@ -24,7 +24,7 @@ class MainActivity : ComponentActivity() {
                     )
                 },
                 content = {
-                    IdledetectorappTheme {
+                    IdleDetectorAppTheme {
                         AppContent()
                     }
                 })

--- a/app/src/main/java/ke/co/banit/idle_detector_app/ui/theme/IdleDetectorAppTheme.kt
+++ b/app/src/main/java/ke/co/banit/idle_detector_app/ui/theme/IdleDetectorAppTheme.kt
@@ -1,6 +1,5 @@
 package ke.co.banit.idle_detector_app.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -34,7 +33,7 @@ private val LightColorScheme = lightColorScheme(
 )
 
 @Composable
-fun IdledetectorappTheme(
+fun IdleDetectorAppTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,


### PR DESCRIPTION
## Summary
- rename the Compose theme composable and source file to IdleDetectorAppTheme
- update the app entry point and README usage snippet to call the new composable name

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: no matching Java toolchain in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c920188ca0832c8b97547c85cec4f0